### PR TITLE
Added Void Linux pkg number support

### DIFF
--- a/src/fetch_functions.h
+++ b/src/fetch_functions.h
@@ -204,6 +204,10 @@ void pkgs()
     // Arch / Pacman
     if(std::filesystem::exists("/etc/pacman.d"))
         pkg = pkg + std::to_string(Pacman("/var/lib/pacman/local/")-1) + " (pacman) ";
+    
+    // Void / X Binary Package System (XBPS)
+    if(std::filesystem::exists("/etc/xbps.d"))
+        pkg = pkg + exec("xbps-query -l | wc -l") + " (xbps-query) ";
 
     // Debian / apt
     if(std::filesystem::exists("/etc/apt"))


### PR DESCRIPTION
Edited the 'src/fetch_functions.h' file and made the program able to print the number of installed packages on a Void Linux system by using the "xbps-query" command, part of the _X Binary Package System_ package manager.